### PR TITLE
Simplified the detection

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -1,34 +1,32 @@
 #include <type_traits>
 
-struct func{
-    template<typename T>
-    static int Do(T){}
+struct func
+{
+	template<typename T>
+	static int Do(T) {}
 };
 
-struct func2{
-    template<typename T1, typename T2>
-    static int Do(T1, T2){}
+struct func2
+{
+	template<typename T1, typename T2>
+	static int Do(T1, T2) {}
 };
-
-template < typename T >
-int val (T const &, int){return 0;};
 
 template <typename Functor>
-struct has_two_args {
+struct has_two_args
+{
+	template <typename Derived, typename = decltype(Derived::Do(0))>
+	static std::false_type test() {};
 
-    struct derived : Functor{};
+	template <typename Derived, typename = decltype(Derived::Do(0, 0))>
+	static std::true_type test() {};
 
-    template <typename Derived>
-    static std::false_type test(decltype(val(Derived::Do(0), 0)) ){};
-
-    template <typename Derived>
-    static std::true_type test( decltype(val(Derived::Do(0,0), 0)) ){};
-
-    typedef decltype (test<derived>(0)) type;
+	typedef decltype(test<Functor>()) type;
+	static const bool Value = type::value;
 };
 
-int main(){
-
-    static_assert(has_two_args<func>::type::value==false, "error");
-    static_assert(has_two_args<func2>::type::value==true, "error");
+int main()
+{
+	static_assert(has_two_args<func>::Value == false, "error");
+	static_assert(has_two_args<func2>::Value == true, "error");
 }


### PR DESCRIPTION
#include <type_traits>

struct func
{
	template<typename T>
	static int Do(T) {}
};

struct func2
{
	template<typename T1, typename T2>
	static int Do(T1, T2) {}
};

template <typename Functor>
struct has_two_args
{
	template <typename Derived, typename = decltype(Derived::Do(0))>
	static std::false_type test() {};

	template <typename Derived, typename = decltype(Derived::Do(0, 0))>
	static std::true_type test() {};

	typedef decltype(test<Functor>()) type;
	static const bool Value = type::value;
};

int main()
{
	static_assert(has_two_args<func>::Value == false, "error");
	static_assert(has_two_args<func2>::Value == true, "error");
}